### PR TITLE
Taxonomy: Fix parsing script and adapt it to new spreadsheet columns

### DIFF
--- a/data/index.ts
+++ b/data/index.ts
@@ -25,6 +25,7 @@ export type IngredientsType = {
 
 export type QuantityType = {
   quantity_name?: string;
+  quantity_api_name?: string;
   quantity_id: QuantityId;
   quantity_default_weight?: string;
   quantity_default_weight_per_unit?: string;

--- a/data/ingredient_taxonomy.json
+++ b/data/ingredient_taxonomy.json
@@ -45,7 +45,7 @@
     },
     "beef": {
       "ingredient_name": "Boeuf",
-      "ingredient_id": "chicken",
+      "ingredient_id": "beef",
       "ingredient_environment": "Le boeuf a un fort impact environnemental.",
       "category_id": "ingredient-principal",
       "quantities": [
@@ -54,7 +54,7 @@
     },
     "lamb": {
       "ingredient_name": "Agneau",
-      "ingredient_id": "beef",
+      "ingredient_id": "lamb",
       "quantity_name": "Viande d'agneau",
       "category_id": "ingredient-principal",
       "quantities": [
@@ -72,7 +72,7 @@
     },
     "carrots": {
       "ingredient_name": "Carottes",
-      "ingredient_id": "onions",
+      "ingredient_id": "carrots",
       "category_id": "vegetables",
       "quantities": [
         "carrot"
@@ -80,7 +80,7 @@
     },
     "courgettes": {
       "ingredient_name": "Courgettes",
-      "ingredient_id": "carrots",
+      "ingredient_id": "courgettes",
       "category_id": "vegetables",
       "quantities": [
         "courgette"
@@ -88,7 +88,7 @@
     },
     "potatoes": {
       "ingredient_name": "Pommes de terre",
-      "ingredient_id": "courgettes",
+      "ingredient_id": "potatoes",
       "category_id": "vegetables",
       "quantities": [
         "potatoes"
@@ -104,7 +104,7 @@
     },
     "rapeseed-oil": {
       "ingredient_name": "Huile de colza",
-      "ingredient_id": "olive-oild",
+      "ingredient_id": "rapeseed-oil",
       "category_id": "fat",
       "quantities": [
         "rapeseed-oil"

--- a/data/ingredient_taxonomy.json
+++ b/data/ingredient_taxonomy.json
@@ -56,6 +56,7 @@
       "ingredient_name": "Agneau",
       "ingredient_id": "lamb",
       "quantity_name": "Viande d'agneau",
+      "quantity_api_name": "Viande d'agneau",
       "category_id": "ingredient-principal",
       "quantities": [
         "lamb"
@@ -114,6 +115,7 @@
   "quantities": {
     "whole-chicken": {
       "quantity_name": "Poulet entier",
+      "quantity_api_name": "Poulet entier",
       "quantity_id": "whole-chicken",
       "quantity_default_weight_per_unit": "1500",
       "quantity_default_number_of_units": "1",
@@ -123,6 +125,7 @@
     },
     "chicken-thigh": {
       "quantity_name": "Cuisses de poulet",
+      "quantity_api_name": "Cuisses de poulet",
       "quantity_id": "chicken-thigh",
       "quantity_default_weight_per_unit": "250",
       "quantity_default_number_of_units": "6",
@@ -132,6 +135,7 @@
     },
     "chicken-breast": {
       "quantity_name": "Blancs de poulet",
+      "quantity_api_name": "Blancs de poulet",
       "quantity_id": "chicken-breast",
       "quantity_default_weight_per_unit": "200",
       "quantity_default_number_of_units": "4",
@@ -141,6 +145,7 @@
     },
     "beef": {
       "quantity_name": "Boeuf",
+      "quantity_api_name": "Boeuf",
       "quantity_id": "beef",
       "quantity_default_weight": "500",
       "quantity_image_url": "https://images.openfoodfacts.org/images/products/021/526/405/7206/front_fr.3.400.jpg",
@@ -149,6 +154,7 @@
     },
     "lamb": {
       "quantity_name": "Agneau",
+      "quantity_api_name": "Agneau",
       "quantity_id": "lamb",
       "quantity_default_weight": "500",
       "quantity_image_url": "https://images.openfoodfacts.org/images/products/249/364/703/8372/front_fr.4.400.jpg",
@@ -157,6 +163,7 @@
     },
     "onion": {
       "quantity_name": "Oignons",
+      "quantity_api_name": "Oignons",
       "quantity_id": "onion",
       "quantity_default_weight_per_unit": "100",
       "quantity_default_number_of_units": "3",
@@ -166,15 +173,17 @@
     },
     "carrot": {
       "quantity_name": "Carottes",
+      "quantity_api_name": "Carottes",
       "quantity_id": "carrot",
       "quantity_default_weight_per_unit": "75",
       "quantity_default_number_of_units": "4",
-      "quantity_image_url": "https://fr.openfoodfacts.org/produit/3420820009040/carottes-sans-marque",
+      "quantity_image_url": "https://images.openfoodfacts.org/images/products/342/082/000/9040/front_fr.8.400.jpg",
       "category_id": "vegetables",
       "ingredient_id": "carrots"
     },
     "courgette": {
       "quantity_name": "Courgette",
+      "quantity_api_name": "Courgette",
       "quantity_id": "courgette",
       "quantity_default_weight_per_unit": "150",
       "quantity_default_number_of_units": "3",
@@ -184,6 +193,7 @@
     },
     "potatoes": {
       "quantity_name": "Pommes de terre",
+      "quantity_api_name": "Pommes de terre",
       "quantity_id": "potatoes",
       "quantity_default_weight": "1000",
       "quantity_image_url": "https://images.openfoodfacts.org/images/products/325/039/991/5578/front_fr.3.400.jpg",
@@ -192,6 +202,7 @@
     },
     "olive-oil": {
       "quantity_name": "Cuillères à soupe d'huile d'olive",
+      "quantity_api_name": "huile d'olive",
       "quantity_id": "olive-oil",
       "quantity_default_weight_per_unit": "10",
       "quantity_default_number_of_units": "2",
@@ -201,6 +212,7 @@
     },
     "rapeseed-oil": {
       "quantity_name": "Cuillères à soupe d'huile de colza",
+      "quantity_api_name": "huile de colza",
       "quantity_id": "rapeseed-oil",
       "quantity_default_weight_per_unit": "10",
       "quantity_default_number_of_units": "2",

--- a/dataset.tsv
+++ b/dataset.tsv
@@ -1,27 +1,27 @@
-Notes:														
-Les champs "id" de types d'ingrédients, d'ingrédients et de quantités sont utiles au cas où on souhaite renommer un type d'ingrédient, ingrédient ou quantité, sans que cela casse la faculté de modifier des recettes pré-existantes qui ont été préalablement sauvegardées														
-														
-Ingredient type	Ingredient type id	Description	Ingredient	Ingredient id	Description	Preparation	Health	Environment	Quantity 	Quantity id	default_weight	default_weight_per_unit	default_number_of_units	
-Ingrédient principal	ingredient-principal	L'ingrédient principal du ragoût est souvent une source de protéines : viande, poisson... 												
-			Poulet	chicken	Le mafé de poulet est l'un des plats les plus populaires d'Afrique.		Le poulet est une viande blanche peu calorique.							
-									Poulet entier	whole-chicken		1500	1	https://images.openfoodfacts.org/images/products/223/389/123/9954/front_fr.3.400.jpg
-									Cuisses de poulet	chicken-thigh		250	6	https://images.openfoodfacts.org/images/products/323/089/002/6553/front_fr.17.400.jpg
-									Blancs de poulet	chicken-breast		200	4	https://images.openfoodfacts.org/images/products/021/040/303/3783/front_fr.3.400.jpg
-			Boeuf	beef				Le boeuf a un fort impact environnemental.						
-									Boeuf	beef	500			https://images.openfoodfacts.org/images/products/021/526/405/7206/front_fr.3.400.jpg
-			Agneau	lamb					Viande d'agneau					
-									Agneau	lamb	500			https://images.openfoodfacts.org/images/products/249/364/703/8372/front_fr.4.400.jpg
-Légumes	vegetables													
-			Oignons	onions		Faire revenir les oignons pour encore plus de goût								
-									Oignons	onion		100	3	https://images.openfoodfacts.org/images/products/318/050/030/1047/front_fr.3.400.jpg
-			Carottes	carrots										
-									Carottes	carrot		75	4	https://fr.openfoodfacts.org/produit/3420820009040/carottes-sans-marque
-			Courgettes	courgettes										
-									Courgette	courgette		150	3	https://images.openfoodfacts.org/images/products/020/351/701/1020/front_fr.4.400.jpg
-			Pommes de terre	potatoes										
-									Pommes de terre	potatoes	1000			https://images.openfoodfacts.org/images/products/325/039/991/5578/front_fr.3.400.jpg
-Matière grasse	fat	La matière grasse permet de faire revenir la viande et/ou certains légumes comme les oignons.												
-			Huile d'olive	olive-oild										
-									Cuillères à soupe d'huile d'olive	olive-oil		10	2	https://images.openfoodfacts.org/images/products/356/007/091/0366/front_fr.70.400.jpg
-			Huile de colza	rapeseed-oil										
-									Cuillères à soupe d'huile de colza	rapeseed-oil		10	2	https://images.openfoodfacts.org/images/products/325/622/171/2254/front_fr.44.400.jpg
+Notes:															
+Les champs "id" de types d'ingrédients, d'ingrédients et de quantités sont utiles au cas où on souhaite renommer un type d'ingrédient, ingrédient ou quantité, sans que cela casse la faculté de modifier des recettes pré-existantes qui ont été préalablement sauvegardées															
+															
+Ingredient type	Ingredient type id	Description	Ingredient	Ingredient id	Description	Preparation	Health	Environment	Quantity displayed	Quantity API name	Quantity id	default_weight	default_weight_per_unit	default_number_of_units	
+Ingrédient principal	ingredient-principal	L'ingrédient principal du ragoût est souvent une source de protéines : viande, poisson... 													
+			Poulet	chicken	Le mafé de poulet est l'un des plats les plus populaires d'Afrique.		Le poulet est une viande blanche peu calorique.								
+									Poulet entier	Poulet entier	whole-chicken		1500	1	https://images.openfoodfacts.org/images/products/223/389/123/9954/front_fr.3.400.jpg
+									Cuisses de poulet	Cuisses de poulet	chicken-thigh		250	6	https://images.openfoodfacts.org/images/products/323/089/002/6553/front_fr.17.400.jpg
+									Blancs de poulet	Blancs de poulet	chicken-breast		200	4	https://images.openfoodfacts.org/images/products/021/040/303/3783/front_fr.3.400.jpg
+			Boeuf	beef				Le boeuf a un fort impact environnemental.							
+									Boeuf	Boeuf	beef	500			https://images.openfoodfacts.org/images/products/021/526/405/7206/front_fr.3.400.jpg
+			Agneau	lamb					Viande d'agneau	Viande d'agneau					
+									Agneau	Agneau	lamb	500			https://images.openfoodfacts.org/images/products/249/364/703/8372/front_fr.4.400.jpg
+Légumes	vegetables														
+			Oignons	onions		Faire revenir les oignons pour encore plus de goût									
+									Oignons	Oignons	onion		100	3	https://images.openfoodfacts.org/images/products/318/050/030/1047/front_fr.3.400.jpg
+			Carottes	carrots											
+									Carottes	Carottes	carrot		75	4	https://images.openfoodfacts.org/images/products/342/082/000/9040/front_fr.8.400.jpg
+			Courgettes	courgettes											
+									Courgette	Courgette	courgette		150	3	https://images.openfoodfacts.org/images/products/020/351/701/1020/front_fr.4.400.jpg
+			Pommes de terre	potatoes											
+									Pommes de terre	Pommes de terre	potatoes	1000			https://images.openfoodfacts.org/images/products/325/039/991/5578/front_fr.3.400.jpg
+Matière grasse	fat	La matière grasse permet de faire revenir la viande et/ou certains légumes comme les oignons.													
+			Huile d'olive	olive-oild											
+									Cuillères à soupe d'huile d'olive	huile d'olive	olive-oil		10	2	https://images.openfoodfacts.org/images/products/356/007/091/0366/front_fr.70.400.jpg
+			Huile de colza	rapeseed-oil											
+									Cuillères à soupe d'huile de colza	huile de colza	rapeseed-oil		10	2	https://images.openfoodfacts.org/images/products/325/622/171/2254/front_fr.44.400.jpg

--- a/parseDataset.js
+++ b/parseDataset.js
@@ -75,11 +75,18 @@ lines.slice(TITLE_LINE + 1).forEach((line) => {
     .some((cell) => cell !== "");
 
   if (isNewCategory) {
-    data.categories[lineObject.category_id] = { ...lineObject, ingredients: [] };
     currentState = { category_id: lineObject.category_id };
+    data.categories[lineObject.category_id] = {
+      ...lineObject,
+      ingredients: [],
+    };
     return;
   }
   if (isNewIngredient) {
+    currentState = {
+      category_id: currentState.category_id,
+      ingredient_id: lineObject.ingredient_id,
+    };
     data.categories[currentState.category_id].ingredients.push(
       lineObject.ingredient_id
     );
@@ -87,10 +94,6 @@ lines.slice(TITLE_LINE + 1).forEach((line) => {
       ...lineObject,
       ...currentState,
       quantities: [],
-    };
-    currentState = {
-      category_id: currentState.category_id,
-      ingredient_id: lineObject.ingredient_id,
     };
     return;
   }

--- a/parseDataset.js
+++ b/parseDataset.js
@@ -30,11 +30,12 @@ const COLUMNS = {
   7: "ingredient_health",
   8: "ingredient_environment",
   9: "quantity_name",
-  10: "quantity_id",
-  11: "quantity_default_weight",
-  12: "quantity_default_weight_per_unit",
-  13: "quantity_default_number_of_units",
-  14: "quantity_image_url",
+  10: "quantity_api_name",
+  11: "quantity_id",
+  12: "quantity_default_weight",
+  13: "quantity_default_weight_per_unit",
+  14: "quantity_default_number_of_units",
+  15: "quantity_image_url",
 };
 
 // Level of depths (end excluded)


### PR DESCRIPTION
This PR can be read commit by commit

It's part of #13. It fixes the bug found in #16 (it was spreading objects before updating them which put ids in the wrong items 🙈) and updates the taxonomy files to support the new column `quatity_api_name`


