### PR TITLE
feat: publish the recipe and redirect to resulting url

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import AppBar from "@/components/AppBar";
 import IngredientSelector from "@/components/IngredientSelector";
 import IngredientCards from "@/components/IngredientCard";
+import PublishRecipe from "@/components/PublishRecipe";
 import "./i18n";
 
 import { useDispatch, useSelector } from "react-redux";
@@ -17,6 +18,7 @@ import Sheet from "@mui/joy/Sheet";
 import ShowNutritionalTable from "@/components/ShowNutritionalTable";
 import Add from "@mui/icons-material/Add";
 import Button from "@mui/joy/Button";
+import Stack from "@mui/joy/Stack";
 import Box from "@mui/joy/Box";
 
 import { useTranslation } from "react-i18next";
@@ -88,15 +90,19 @@ export default function Home() {
           borderTopRightRadius: "10px",
         }}
       >
+        <Stack direction="row" spacing={2} alignItems="center"
+  justifyContent="center">
         <Button
           variant="solid"
           color="primary"
           startDecorator={<Add />}
           onClick={() => dispatch(openEditor({}))}
-          sx={{ mb: 2 }}
         >
           {t("actions.add_ingredient")}
         </Button>
+        <PublishRecipe />
+        </Stack>
+
         <ShowNutritionalTable />
       </Sheet>
       <IngredientSelector />

--- a/components/PublishRecipe.tsx
+++ b/components/PublishRecipe.tsx
@@ -86,7 +86,7 @@ const PublishRecipe = () => {
       .then((data) => {
         console.log(data);
         if (data.url) {
-            window.location.replace(data.url);
+            window.location.assign(data.url);
         }
         return data;
       })

--- a/components/PublishRecipe.tsx
+++ b/components/PublishRecipe.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import * as React from "react";
+
+import { useSelector } from "react-redux";
+import { selectCurrentIngredients, selectURLParams } from "@/redux/selectors";
+import store, { RootState } from "@/redux/store";
+import Send from "@mui/icons-material/Send";
+import Button from "@mui/joy/Button";
+import { useTranslation } from "react-i18next";
+import data from "../data";
+
+const PublishRecipe = () => {
+  const [open, setOpen] = React.useState(false);
+  const { t } = useTranslation();
+
+  const params = useSelector((state: RootState) =>
+    selectURLParams(state, "userRecipe")
+  );
+
+  // The share button makes a POST request to publish_url and sends the ingredients and scores
+  function handlePublishRecipeButtonClick() {
+    const url =
+      new URLSearchParams(document.location.search).get("publish_url") ||
+      "https://amathjourney.com/api/yololo";
+
+    // get the scores
+    const nutriscore = store.getState().recipe.recipes.userRecipe.nutriscore;
+    const nutriscore_100 =
+      store.getState().recipe.recipes.userRecipe.nutriscore_100;
+    const ecoscore = store.getState().recipe.recipes.userRecipe.ecoscore;
+    const ecoscore_100 =
+      store.getState().recipe.recipes.userRecipe.ecoscore_100;
+
+    // build a list of ingredients with their name, weight and unit
+    const currentIngredients = selectCurrentIngredients(
+      store.getState(),
+      "userRecipe"
+    );
+
+    const ingredients = currentIngredients.flatMap((ingredient) => {
+      const ingredientData = data.ingredients[ingredient.id];
+
+      return ingredient.quantities.map((quantity) => {
+        const quantityData = data.quantities[quantity.id];
+
+        const isPerUnit =
+          quantityData.quantity_default_weight_per_unit !== undefined;
+
+        const weight =
+          quantity.value *
+          (isPerUnit ? quantityData.quantity_default_weight_per_unit! : 1);
+
+        const ingredientName =
+          quantityData.quantity_ingredient_name ||
+          ingredientData.ingredient_name;
+
+        return {
+          name: ingredientName,
+          weight: weight,
+          unit: quantityData.quantity_unit!,
+          quantity_value: quantity.value,
+          quantity_name: quantityData.quantity_name_plural
+        };
+      });
+    });
+
+    const body = JSON.stringify({
+      // the return_url allows to go back to the current recipe
+      return_url: `${window.location.origin}${window.location.pathname}?${params}`,
+      ingredients,
+      nutriscore,
+      nutriscore_100,
+      ecoscore,
+      ecoscore_100,
+    });
+
+    fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: body,
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data);
+        if (data.url) {
+            window.location.replace(data.url);
+        }
+        return data;
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+  return (
+
+    <Button
+    variant="solid"
+    color="primary"
+    startDecorator={<Send />}
+    onClick={() => handlePublishRecipeButtonClick()}
+    sx={{ mb: 2 }}
+  >
+    {t("actions.publish_recipe")}
+  </Button>
+
+  );
+};
+
+export default PublishRecipe;

--- a/components/PublishRecipe.tsx
+++ b/components/PublishRecipe.tsx
@@ -87,7 +87,6 @@ const PublishRecipe = () => {
         if (data.url) {
             window.location.assign(data.url);
         }
-        return data;
       })
       .catch((error) => {
         console.error(error);

--- a/components/PublishRecipe.tsx
+++ b/components/PublishRecipe.tsx
@@ -84,7 +84,6 @@ const PublishRecipe = () => {
     })
       .then((response) => response.json())
       .then((data) => {
-        console.log(data);
         if (data.url) {
             window.location.assign(data.url);
         }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,7 +6,8 @@
     "prev": "Prev",
     "next": "Next",
     "cancel": "Cancel",
-    "validate": "Validate"
+    "validate": "Validate",
+    "publish_recipe": "Publish the recipe"
   },
   "nutriments": {
     "unknown": "N/A",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -6,7 +6,8 @@
     "prev": "Prev",
     "next": "Suivant",
     "cancel": "Annuler",
-    "validate": "Valider"
+    "validate": "Valider",
+    "publish_recipe": "Publier la recette"
   },
   "nutriments": {
     "unknown": "N/A",


### PR DESCRIPTION
If we have a publish_url parameter, we can POST the recipe to it, then get back a JSON with a url field, and redirect to it.

For testing, I created https://world.openfoodfacts.org/cgi/ratemyrecipe_redirect_test.pl which just returns this:

```
  HTTP/1.1 200 OK
  Server: nginx/1.10.3
  Date: Thu, 29 Jun 2023 17:09:42 GMT
  Content-Type: application/json
  Transfer-Encoding: chunked
  Connection: keep-alive
  Access-Control-Allow-Origin: *
  Access-Control-Allow-Methods: GET,OPTIONS,POST
  Access-Control-Allow-Headers: Content-Type
  Strict-Transport-Security: max-age=63072000
  X-Frame-Options: DENY
  X-Content-Type-Options: nosniff

{"url":"https://www.iri.centrepompidou.fr/non-classe/projet-contribalim/"}
```

To test: https://deploy-preview-35--contribalim.netlify.app/?publish_url=https://world.openfoodfacts.org/cgi/ratemyrecipe_redirect_test.pl