### PR TITLE
fix dataset and add error check in parseDataset.js

### DIFF
--- a/data/ingredients_config.json
+++ b/data/ingredients_config.json
@@ -17,7 +17,7 @@
         "eggplant",
         "beetroot-cooked",
         "carrot",
-        "celeri-branche",
+        "celery-branch",
         "white-cabbage",
         "green-cabbage",
         "courgettes",
@@ -173,12 +173,12 @@
         "carrot"
       ]
     },
-    "celeri-branche": {
+    "celery-branch": {
       "ingredient_name": "Céleri branche",
-      "ingredient_id": "celeri-branche",
+      "ingredient_id": "celery-branch",
       "category_id": "vegetables",
       "quantities": [
-        "celeri-branche.unit"
+        "celery-branch.unit"
       ]
     },
     "white-cabbage": {
@@ -209,7 +209,9 @@
       "ingredient_name": "Epinard",
       "ingredient_id": "spinach",
       "category_id": "vegetables",
-      "quantities": []
+      "quantities": [
+        "spinach"
+      ]
     },
     "onions": {
       "ingredient_name": "Oignon",
@@ -777,19 +779,19 @@
       "ingredient_id": "carrot",
       "ingredient_name": "Carotte"
     },
-    "celeri-branche.unit": {
+    "celery-branch.unit": {
       "quantity_name_plural": "branches",
       "quantity_name_singular": "branche",
       "quantity_unit_id": "unit",
       "quantity_default_weight_per_unit": 100,
       "quantity_default_number_of_units": 2,
       "quantity_image_url": "https://images.openfoodfacts.org/images/products/200/771/400/0003/front_fr.3.400.jpg",
-      "quantity_id": "celeri-branche.unit",
+      "quantity_id": "celery-branch.unit",
       "quantity_unit": "g",
       "quantity_ingredient_name": "Céleri branche",
       "quantity_step": 1,
       "category_id": "vegetables",
-      "ingredient_id": "celeri-branche",
+      "ingredient_id": "celery-branch",
       "ingredient_name": "Céleri branche"
     },
     "white-cabbage.unit": {
@@ -836,6 +838,17 @@
       "category_id": "vegetables",
       "ingredient_id": "courgettes",
       "ingredient_name": "Courgette"
+    },
+    "spinach": {
+      "quantity_default_weight": 100,
+      "quantity_image_url": "https://images.openfoodfacts.org/images/products/540/014/126/8898/front_fr.4.400.jpg",
+      "quantity_id": "spinach",
+      "quantity_unit": "g",
+      "quantity_ingredient_name": "Epinard",
+      "quantity_step": 1,
+      "category_id": "vegetables",
+      "ingredient_id": "spinach",
+      "ingredient_name": "Epinard"
     },
     "onions.unit": {
       "quantity_name_plural": "oignon",

--- a/dataset.tsv
+++ b/dataset.tsv
@@ -25,7 +25,7 @@ Légumes	vegetables
 														500			100	https://images.openfoodfacts.org/images/products/328/144/000/0035/front_fr.15.400.jpg
 			Carotte	carrot														
 														500			100	https://images.openfoodfacts.org/images/products/342/082/000/9040/front_fr.8.400.jpg
-			Céleri branche	celeri-branche														
+			Céleri branche	celery-branch														
 									branches	branche		unit			100	2		https://images.openfoodfacts.org/images/products/200/771/400/0003/front_fr.3.400.jpg
 			Chou blanc	white-cabbage														
 									chou	choux		unit			1500	1		https://images.openfoodfacts.org/images/products/370/065/157/6660/front_fr.3.400.jpg
@@ -34,7 +34,7 @@ Légumes	vegetables
 			Courgette	courgettes														
 									courgettes	courgette		unit			150	3		https://images.openfoodfacts.org/images/products/020/351/701/1020/front_fr.4.400.jpg
 			Epinard	spinach														
-																		https://images.openfoodfacts.org/images/products/540/014/126/8898/front_fr.4.400.jpg
+														100				https://images.openfoodfacts.org/images/products/540/014/126/8898/front_fr.4.400.jpg
 			Oignon	onions														
 									oignon	oignons		unit			150	2		https://images.openfoodfacts.org/images/products/318/050/030/1047/front_fr.3.400.jpg
 			Piment vert	green-chili-pepper														

--- a/parseDataset.js
+++ b/parseDataset.js
@@ -158,6 +158,18 @@ lines.slice(TITLE_LINE + 1).forEach((line) => {
   }
 });
 
+// Check that we don't have ingredients without quantities
+Object.values(data.categories).forEach((category) => {
+  console.log("category: " + category.category_id);
+  category.ingredients.forEach((ingredient_id) => {
+    console.log("- ingredient: " + ingredient_id);
+    ingredient = data.ingredients[ingredient_id];
+    if (ingredient.quantities.length == 0) {
+      throw new Error("no quantities defined for ingredient " + ingredient.ingredient_id);
+    }
+  });
+});
+
 fs.writeFile(
   "./data/ingredients_config.json",
   JSON.stringify(data, null, 2),


### PR DESCRIPTION
Vegetables were broken because one vegetable (spinach) had no quantity defined. This PR fixes it, and also adds a check when parsing the dataset.tsv file.