### PR TITLE
fix: add general category for nutriscore, publish only when nutriscore is computed

### DIFF
--- a/components/AppBar/TooltipButtons.tsx
+++ b/components/AppBar/TooltipButtons.tsx
@@ -14,11 +14,6 @@ export const TooltipButtons = ({
 }: TooltipButtonsProps) => {
   return (
     <Stack spacing={1} direction={"row"}>
-      <Tooltip title="Partager un lien">
-        <IconButton onClick={onShareButtonClick}>
-          <ShareIcon />
-        </IconButton>
-      </Tooltip>
       <Tooltip title="Enregistrer la recette">
         <IconButton onClick={onSaveRecipe}>
           <SaveIcon />

--- a/components/PublishRecipe.tsx
+++ b/components/PublishRecipe.tsx
@@ -19,6 +19,9 @@ const PublishRecipe = () => {
   const currentIngredients = useSelector((state: RootState) =>
     selectCurrentIngredients(state, "userRecipe")
   );
+  const currentNutriscore = useSelector(
+    (state: RootState) => state.recipe.recipes["userRecipe"].nutriscore
+  );
 
   // The share button makes a POST request to publish_url and sends the ingredients and scores
   function handlePublishRecipeButtonClick() {
@@ -96,7 +99,8 @@ const PublishRecipe = () => {
       });
   }
   // Display the publish button only if we have at least one ingredient
-  if (currentIngredients.length > 0) {
+  // and a Nutri-Score computed
+  if ((currentIngredients.length > 0)  && (currentNutriscore !== undefined)) {
     return (
       <Button
         variant="solid"

--- a/redux/reducers/editor.ts
+++ b/redux/reducers/editor.ts
@@ -40,7 +40,7 @@ type EditorState = {
   ingredientId?: string | null;
   quantityId?: string | null;
   quantityValue?: number | null;
-  // This identify the modified ingredient, such that we cvan delete it if validated
+  // This identifies the modified ingredient, so that we can delete it if validated
   modifiedIngredient?: {
     categoryId: string | null;
     ingredientId: string | null;

--- a/redux/reducers/recipes.ts
+++ b/redux/reducers/recipes.ts
@@ -55,9 +55,9 @@ export const updateRecipeIngredients = createAsyncThunk(
             "ingredients,nutriments_estimated,nutriscore_grade,nutriscore_score,ecoscore_grade,ecoscore_score",
           product: {
             lang: "fr",
-            // disable the Eco-Score by not sending a category, as we don't have recipe specific Eco-Score
-            // implemented on the server.
-            // categories_tags: ["Cassoulets au confit de canard"],
+            // disable the Eco-Score by not sending a precise category, as we don't have recipe specific Eco-Score
+            // implemented on the server. We do need an imprecise category in order to compute the Nutri-Score.
+            categories_tags: ["en:soups"],
             ingredients_text_fr: ingredients,
           },
         }),


### PR DESCRIPTION
- in the current nutriscore API, there's a bug and a nutriscore is computed even if we don't have a category, this will be fixed server side, so we need to send a generic category in order to compute the nutriscore
- if we don't have a nutriscore computed, we remove the publish feature