### PR TITLE
Fix: Get image responsive with `ResponsiveImage` component

### DIFF
--- a/components/IngredientCards/IngredientPicture.tsx
+++ b/components/IngredientCards/IngredientPicture.tsx
@@ -1,6 +1,6 @@
-import Typography from "@mui/joy/Typography";
-import AspectRatio from "@mui/joy/AspectRatio";
 import * as React from "react";
+import Typography from "@mui/joy/Typography";
+import ResponsiveImage from "@/components/shared/atoms/ResponsiveImage";
 
 interface IngredientPictureProps {
   ingredientName: string | undefined;
@@ -18,14 +18,14 @@ export const IngredientPicture = ({
       </Typography>
       {/* <Typography level="body2">({props.quantity_name})</Typography> */}
 
-      <AspectRatio
-        minHeight="150px"
-        maxHeight="300px"
+      <ResponsiveImage
+        minHeight="50px"
+        maxHeight="150px"
         objectFit="contain"
         sx={{ my: 1 }}
-      >
-        <img src={imageUrl} loading="lazy" alt="" />
-      </AspectRatio>
+        src={imageUrl}
+        alt=""
+      />
     </>
   );
 };

--- a/components/IngredientSelector/IngredientCardSingleView.tsx
+++ b/components/IngredientSelector/IngredientCardSingleView.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { CardContent, Input, Typography } from "@mui/joy";
-import { ValueEditor } from "../shared/molecules/ValueEditor";
 import { ChangeEvent } from "react";
 import { ImagePlaceholder } from "@/components/shared/atoms/ImagePlaceholder";
 import Card from "@mui/joy/Card";
-import { CardMedia } from "@mui/material";
+import { ValueEditor } from "@/components/shared/molecules/ValueEditor";
+import ResponsiveImage from "@/components/shared/atoms/ResponsiveImage";
 
 interface QuantityCardProps {
   onIncrement(): void;
@@ -16,6 +16,7 @@ interface QuantityCardProps {
   title: string | undefined;
   step?: number;
 }
+
 export function IngredientCardSingleView({
   onIncrement,
   onDecrement,
@@ -44,10 +45,10 @@ export function IngredientCardSingleView({
         </Typography>
       </CardContent>
       {imgSrc ? (
-        <CardMedia
-          component="img"
-          height={"30%"}
-          image={imgSrc || ""}
+        <ResponsiveImage
+          minHeight={100}
+          maxHeight={150}
+          src={imgSrc || ""}
           alt={title}
         />
       ) : (

--- a/components/shared/atoms/ResponsiveImage.tsx
+++ b/components/shared/atoms/ResponsiveImage.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { AspectRatio, AspectRatioProps } from "@mui/joy";
+
+interface ResponsiveImageProps
+  extends Pick<
+      AspectRatioProps,
+      "minHeight" | "maxHeight" | "objectFit" | "sx"
+    >,
+    React.ImgHTMLAttributes<Element> {
+  width?: string | number;
+}
+
+export default function ResponsiveImage(props: ResponsiveImageProps) {
+  const {
+    minHeight,
+    maxHeight,
+    width = "100%",
+    objectFit = "contain",
+    sx,
+    ...other
+  } = props;
+
+  return (
+    <AspectRatio
+      minHeight={minHeight}
+      maxHeight={maxHeight}
+      objectFit={objectFit}
+      sx={{ width, ...sx }}
+    >
+      <img alt="" {...other} />
+    </AspectRatio>
+  );
+}

--- a/components/shared/molecules/GenericCard.tsx
+++ b/components/shared/molecules/GenericCard.tsx
@@ -1,8 +1,8 @@
 import Card from "@mui/joy/Card";
-import { CardMedia } from "@mui/material";
 import { CardContent, Stack, Typography } from "@mui/joy";
 import React from "react";
 import { ImagePlaceholder } from "@/components/shared/atoms/ImagePlaceholder";
+import ResponsiveImage from "@/components/shared/atoms/ResponsiveImage";
 
 interface GenericCardProps {
   title: string | undefined;
@@ -30,10 +30,12 @@ export function GenericCard({
       onClick={onClick}
     >
       {imgUrl && (
-        <CardMedia
-          component="img"
-          height={90}
-          image={imgUrl || ""}
+        <ResponsiveImage
+          minHeight="100px"
+          maxHeight="150px"
+          objectFit="contain"
+          sx={{ my: 1 }}
+          src={imgUrl}
           alt={title}
         />
       )}


### PR DESCRIPTION
I introduce `ResponsiveImage` component that expects a `minHeight`, `maxHeight` and lets the image fit in it

It's not trivial to know where cards are defined. I might need to do some file organisation